### PR TITLE
support shift composition keys

### DIFF
--- a/Arduino_source/X2Kbd/Debug.cpp
+++ b/Arduino_source/X2Kbd/Debug.cpp
@@ -5,7 +5,7 @@
  */
 
 #include <Arduino.h>
-#include <String.h>
+#include <WString.h>
 
 #include "Common.h"
 #include "Debug.h"

--- a/Arduino_source/X2Kbd/Translate.h
+++ b/Arduino_source/X2Kbd/Translate.h
@@ -22,4 +22,6 @@ protected:
     bool    m_isCAPS;
     bool    m_isHANGUL;
     bool    m_oldShifted;
+    bool m_fakeShift;
+    int m_fakeKey;
 };

--- a/Arduino_source/X2Kbd/X2Keyboard.cpp
+++ b/Arduino_source/X2Kbd/X2Keyboard.cpp
@@ -23,7 +23,63 @@ void CX2Keyboard::init()
 }
 
 void CX2Keyboard::process() 
-{    
+{
+// uncomment the next line to use emulation mode!
+// #define NO_X2_KEYBOARD 1
+#if NO_X2_KEYBOARD
+//====================================================================
+  if (Serial.available()) {
+    char c = Serial.read();
+    switch (c) {
+      case '0': // release all
+        DBGLN("* release all");
+        memset(m_readVal, 0, sizeof(m_readVal));
+        break;
+      case '1': 
+        DBGLN("* press Shift+F1 -> F6: 0x0b");
+        m_readVal[6] |= 0x80 | 0x04;
+        break;
+      case '2':
+        DBGLN("* press @ -> Shift+2: 0x12 0x1e");
+        m_readVal[1] |= 0x04;
+        // FIXME: missing *unfake* press shift
+        break;
+      case '3': 
+        DBGLN("* press Caps -> Caps: 0x58");
+        m_readVal[6] |= 0x10;
+        break;
+      case '4': 
+        DBGLN("* press Graph -> LeftAlt: 0x11");
+        m_readVal[6] |= 0x20;
+        break;
+      case '5': 
+        DBGLN("* press Ctrl -> LeftCtrl: 0x14");
+        m_readVal[6] |= 0x40;
+        break;
+      case '6': 
+        DBGLN("* press Shift+6(&) -> Shift+7: 0x12 0x3d");
+        m_readVal[6] |= 0x80;
+        m_readVal[0] |= 0x02;
+        break;
+      case '7': 
+        DBGLN("* press Shift+7(') -> QUOTE('): 0x52");
+        m_readVal[6] |= 0x80;
+        m_readVal[0] |= 0x01;
+        // FIXME: missing unfake press shift
+        break;
+      case '?': 
+        for(int row = 0; row < sizeX; row++) {
+          DBG("* ");
+          for (int bit = 0; bit < sizeY; bit++) {
+            DBG(m_readVal[row] & (1 << bit) ? "1 " : "0 ");
+          }
+          DBG(": ");DBGLN(row);
+        }
+        break;
+    }
+  }
+//====================================================================
+#else
     for( int XS = 0; XS < sizeX; XS ++ )
     {
         digitalWrite( m_pinCLK, LOW );
@@ -52,6 +108,7 @@ void CX2Keyboard::process()
         DBG(">x2:");
         Dump( sizeX, m_readVal );
     }
+#endif
 }
 
 void CX2Keyboard::SetLed_CAPS(bool isOn)

--- a/Arduino_source/X2Kbd/msxscancode.h
+++ b/Arduino_source/X2Kbd/msxscancode.h
@@ -1,0 +1,113 @@
+#ifndef __MSXSCANCODE_H__
+#define __MSXSCANCODE_H__
+
+// my own msx scan code based on MSX keyboard matrix
+// https://www.msx.org/wiki/Keyboard_Matrices
+// <scancode> ::= <row> <bit>
+// <row> ::= b7..b4
+// <bit> ::= b3..b0
+
+#define MSX_ROW(code) (((code)&0xf0)>>4)
+#define MSX_BIT(code) ((code)&0x0f)
+#define MSX_CODE(row,bit) (((row)<<4)|(bit))
+
+#define MSX_7   MSX_CODE(0,7)
+#define MSX_6   MSX_CODE(0,6)
+#define MSX_5   MSX_CODE(0,5)
+#define MSX_4   MSX_CODE(0,4)
+#define MSX_3   MSX_CODE(0,3)
+#define MSX_2   MSX_CODE(0,2)
+#define MSX_1   MSX_CODE(0,1)
+#define MSX_0   MSX_CODE(0,0)
+
+#define MSX_SEMICOLON           MSX_CODE(1,7)
+#define MSX_LEFT_ANGLE_BRAKET   MSX_CODE(1,6)
+#define MSX_AT                  MSX_CODE(1,5)
+#define MSX_KRW                 MSX_CODE(1,4)
+#define MSX_CARET               MSX_CODE(1,3)
+#define MSX_MINUS               MSX_CODE(1,2)
+#define MSX_9                   MSX_CODE(1,1)
+#define MSX_8                   MSX_CODE(1,0)
+
+#define MSX_B                   MSX_CODE(2,7)
+#define MSX_A                   MSX_CODE(2,6)
+#define MSX_UNDERSCORE          MSX_CODE(2,5)
+#define MSX_SLASH               MSX_CODE(2,4)
+#define MSX_PERIOD              MSX_CODE(2,3)
+#define MSX_COMMA               MSX_CODE(2,2)
+#define MSX_RIGHT_ANGLE_BRACKET MSX_CODE(2,1)
+#define MSX_COLON               MSX_CODE(2,0)
+
+#define MSX_J   MSX_CODE(3,7)
+#define MSX_I   MSX_CODE(3,6)
+#define MSX_H   MSX_CODE(3,5)
+#define MSX_G   MSX_CODE(3,4)
+#define MSX_F   MSX_CODE(3,3)
+#define MSX_E   MSX_CODE(3,2)
+#define MSX_D   MSX_CODE(3,1)
+#define MSX_C   MSX_CODE(3,0)
+
+#define MSX_R   MSX_CODE(4,7)
+#define MSX_Q   MSX_CODE(4,6)
+#define MSX_P   MSX_CODE(4,5)
+#define MSX_O   MSX_CODE(4,4)
+#define MSX_N   MSX_CODE(4,4)
+#define MSX_M   MSX_CODE(4,3)
+#define MSX_L   MSX_CODE(4,2)
+#define MSX_K   MSX_CODE(4,0)
+
+#define MSX_Z   MSX_CODE(5,7)
+#define MSX_Y   MSX_CODE(5,6)
+#define MSX_X   MSX_CODE(5,5)
+#define MSX_W   MSX_CODE(5,4)
+#define MSX_V   MSX_CODE(5,3)
+#define MSX_U   MSX_CODE(5,2)
+#define MSX_T   MSX_CODE(5,1)
+#define MSX_S   MSX_CODE(5,0)
+
+#define MSX_F3          MSX_CODE(6,7)
+#define MSX_F2          MSX_CODE(6,6)
+#define MSX_F1          MSX_CODE(6,5)
+#define MSX_HANGUL      MSX_CODE(6,4)
+#define MSX_CAPS        MSX_CODE(6,3)
+#define MSX_GRAPH       MSX_CODE(6,2)
+#define MSX_CTRL        MSX_CODE(6,1)
+#define MSX_SHIFT       MSX_CODE(6,0)
+
+#define MSX_RETURN      MSX_CODE(7,7)
+#define MSX_SELECT      MSX_CODE(7,6)
+#define MSX_BACKSPACE   MSX_CODE(7,5)
+#define MSX_STOP        MSX_CODE(7,4)
+#define MSX_TAB         MSX_CODE(7,3)
+#define MSX_ESC         MSX_CODE(7,2)
+#define MSX_F5          MSX_CODE(7,1)
+#define MSX_F4          MSX_CODE(7,0)
+
+#define MSX_RIGHT_ARROW MSX_CODE(8,7)
+#define MSX_DOWN_ARROW  MSX_CODE(8,6)
+#define MSX_UP_ARROW    MSX_CODE(8,5)
+#define MSX_LEFT_ARROW  MSX_CODE(8,4)
+#define MSX_SUP         MSX_CODE(8,3)
+#define MSX_INS         MSX_CODE(8,2)
+#define MSX_HOME        MSX_CODE(8,1)
+#define MSX_SPACE       MSX_CODE(8,0)
+
+#define MSX_KP_4        MSX_CODE(9,7)
+#define MSX_KP_3        MSX_CODE(9,6)
+#define MSX_KP_2        MSX_CODE(9,5)
+#define MSX_KP_1        MSX_CODE(9,4)
+#define MSX_KP_0        MSX_CODE(9,3)
+#define MSX_KP_SLASH    MSX_CODE(9,2)
+#define MSX_KP_PLUS     MSX_CODE(9,1)
+#define MSX_KP_ASTERISK MSX_CODE(9,0)
+
+#define MSX_KP_PERIOD   MSX_CODE(10,7)
+#define MSX_KP_COMMA    MSX_CODE(10,6)
+#define MSX_KP_MINUS    MSX_CODE(10,5)
+#define MSX_KP_9        MSX_CODE(10,4)
+#define MSX_KP_8        MSX_CODE(10,3)
+#define MSX_KP_7        MSX_CODE(10,2)
+#define MSX_KP_6        MSX_CODE(10,1)
+#define MSX_KP_5        MSX_CODE(10,0)
+
+#endif

--- a/Arduino_source/X2Kbd/ps2dev.h
+++ b/Arduino_source/X2Kbd/ps2dev.h
@@ -10,10 +10,10 @@
 #define ps2dev_h
 
 #ifndef PS2_CLOCK_PIN
-#define PS2_CLOCK_PIN 3
+#define PS2_CLOCK_PIN PIN_A0
 #endif
 #ifndef PS2_DATA_PIN
-#define PS2_DATA_PIN 2
+#define PS2_DATA_PIN PIN_A1
 #endif
 
 #include "Arduino.h"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-# X2Kbd
-Use the Daewoo MSX2 X-2 (CPC-400) Keyboard with Korean Modern PC (via arduino pro micro USB Port)
+# X2Kbd-ps2
+
+Use the Daewoo MSX2 X-2 (CPC-400) Keyboard as PS/2 Keyboard using Arduino Pro Micro
+
+> Original USB output version is https://github.com/cloudree/X2Kbd
 
 # copyright
 GNU GPL
@@ -13,7 +16,7 @@ GNU GPL
 2. set up a arduino pro micro with source (from this github)
 
 3. connect betwwen the arduino and CPC-300 Keyboard's 14 pin connector of inner PCB
-  a. connection map
+  a. Arconnection map
     * Arduino = 14pin connector of PCB in keyboard
     * D2 = 1 (CAPS)
     * D3 = 2 (CODE/HAN)
@@ -29,34 +32,20 @@ GNU GPL
     * VCC = 12 (VCC)
     * GND = 13 (GND)
     * GND = 14 (GND)
+    * A0 = PS/2 CLOCK
+    * A1 = PS/2 DATA
+    * GND = PS/2 GND
 
-4. assemble keyboard and plug into PC USB
+4. assemble keyboard and plug into PS/2 port on PC, and pray...
 
-5. Special Key Mapping
-    * all key is functional as "key cap described" 
-      eg) Shift + 2 is " (double quotation) in CPC-300 keyboard, so this key is act as " (not pc keyaboard's @)
-    * some special key (no existed in PC Keyboard) is mapped as :
-      
-    * CPC-300 Keyboard = PC
-    * Graph = ALT
-    * STOP = F11
-    * SELECT = F12
-    * INS = END
-    * Shift + DEL = INS
-    * numeric 0 = INS
-    * numeric 1 = END
-    * numeric 2 = cursor down
-    * numeric 3 = PgDn
-    * numeric 4 = cursor left
-    * numeric 5 = (none)
-    * numeric 6 = cursor right
-    * numeric 7 = HOME
-    * numeric 8 = cursor up
-    * numeric 9 = PgDn
-    * numeric / = PrtScr
-    * numeric * = ScrLck
-    * numeric - = PAUSE
-    * numeric + = Korean-Chinese Translate (한자변환)
-    * numeric . = DEL
-    * numeric , = Korean-English Translate (한영전환)
-      
+5. Key Mapping
+    * Keep the printed keys on X2 keycap as possible as I can.
+    * Some PS/2 only keys are not supported. (ex. DEL, END, PGUP, PGDN, ...)
+    * Shift+F1..F5 keys = F6..F10. So Shift+F1..F5 keys are not supported.
+    * Graph = LEFT_ALT
+    * Korean = RIGHT_ALT
+    * At this time, you could define X -> X, X -> Y, Shift+X -> X or X -> Shift+Y, ShiftX -> Shift+Y
+    * see [Translate.cpp](Arduino_source/X2Kbd/Translate.cpp#L32)
+
+---
+May the **SOURECE** be with you...


### PR DESCRIPTION
- Support various composition with Shift:
  - X -> Shift+Y
  - Shift+X -> Y
  - Shift+X -> Shift+Y
- Add X2 Keyboard Emulation Mode(test input without X2 keyboard)
- Change default PS/2 Clock Pin to A0, PS/2 Data Pin to A1
- Update README
- Cleanup logs
- ...

fix #1